### PR TITLE
feat: upstream caremaster infra — scheduled ECS jobs (list command + timezone/retry/DLQ), realtime/SSE ALB, Amplify DNS

### DIFF
--- a/app/api_buckets.go
+++ b/app/api_buckets.go
@@ -37,10 +37,15 @@ type CORSRule struct {
 
 // BucketConfig represents bucket configuration from YAML
 type BucketConfig struct {
-	Name       string       `yaml:"name"`
-	Public     bool         `yaml:"public"`
-	Versioning *bool        `yaml:"versioning"`
-	CORSRules  []CORSConfig `yaml:"cors_rules"`
+	Name       string `yaml:"name"`
+	Public     bool   `yaml:"public"`
+	Versioning *bool  `yaml:"versioning"`
+	// CORSRules must be omitempty: a typed load->save round-trip otherwise
+	// injects an explicit `cors_rules: []` into every bucket, which renders as
+	// `"cors_rules":[]` in the buckets JSON and defeats the modules/s3 variable
+	// default (length(cors_rules) > 0 gate) — terraform plan then proposes
+	// deleting the live aws_s3_bucket_cors_configuration.
+	CORSRules []CORSConfig `yaml:"cors_rules,omitempty"`
 }
 
 // CORSConfig represents CORS configuration from YAML

--- a/app/migrations.go
+++ b/app/migrations.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 )
@@ -29,7 +31,8 @@ import (
 // 18: Move test_emails to global SES level (account-wide, not per-domain)
 // 19: Add enabled field to services (default true, allows disabling without removing config)
 // 20: Add enabled field to scheduled_tasks and event_processor_tasks (same pattern as services)
-const CurrentSchemaVersion = 20
+// 21: Normalize scheduled_tasks[].container_command from scalar string to list(string)
+const CurrentSchemaVersion = 21
 
 // EnvWithVersion extends Env with a schema version field
 type EnvWithVersion struct {
@@ -140,6 +143,11 @@ var AllMigrations = []Migration{
 		Version:     20,
 		Description: "Add enabled field to scheduled_tasks and event_processor_tasks",
 		Apply:       migrateToV20,
+	},
+	{
+		Version:     21,
+		Description: "Normalize scheduled_tasks container_command from scalar string to list(string)",
+		Apply:       migrateToV21,
 	},
 }
 
@@ -1133,6 +1141,90 @@ func migrateToV20(data map[string]interface{}) error {
 	}
 
 	return nil
+}
+
+// migrateToV21 normalizes scheduled_tasks[].container_command from a scalar string
+// (previously devs hand-wrote an HCL list literal as a string, e.g. '["bun","run","x.ts"]')
+// into a real YAML list(string), matching the event_processor_tasks format.
+// It is safe and idempotent: lists are left untouched; a scalar that looks like a
+// JSON/HCL array literal is parsed into its elements; any other scalar is wrapped as a
+// single-element list.
+func migrateToV21(data map[string]interface{}) error {
+	fmt.Println("  → Migrating to v21: Normalizing scheduled_tasks container_command to list(string)")
+
+	tasksRaw, exists := data["scheduled_tasks"]
+	if !exists || tasksRaw == nil {
+		fmt.Println("    ℹ️  No scheduled_tasks to migrate")
+		return nil
+	}
+
+	tasks, ok := tasksRaw.([]interface{})
+	if !ok {
+		fmt.Println("    ⚠️  scheduled_tasks is not an array, skipping migration")
+		return nil
+	}
+
+	updatedCount := 0
+	for _, taskRaw := range tasks {
+		taskMap, ok := taskRaw.(map[interface{}]interface{})
+		if !ok {
+			continue
+		}
+
+		cmdRaw, hasCmd := taskMap["container_command"]
+		if !hasCmd || cmdRaw == nil {
+			continue
+		}
+
+		// Already a list (this migration is idempotent) → leave it alone.
+		if _, isList := cmdRaw.([]interface{}); isList {
+			continue
+		}
+
+		cmdStr, ok := cmdRaw.(string)
+		if !ok {
+			// Not a string and not a list — leave it for the loader to reject loudly.
+			continue
+		}
+
+		taskMap["container_command"] = scalarCommandToList(cmdStr)
+		updatedCount++
+		if name, _ := taskMap["name"].(string); name != "" {
+			fmt.Printf("    ✓ scheduled_task '%s': Converted container_command to list\n", name)
+		}
+	}
+
+	if updatedCount == 0 {
+		fmt.Println("    ℹ️  All scheduled_tasks container_command already in list form")
+	} else {
+		fmt.Printf("    ✓ Converted container_command to list on %d scheduled_task(s)\n", updatedCount)
+	}
+
+	return nil
+}
+
+// scalarCommandToList converts a single container_command scalar string into a list of
+// arguments. A value that looks like a JSON/HCL array literal (e.g. '["bun","run","x.ts"]')
+// is parsed into its elements; anything else is wrapped as a single-element list so the
+// original value is never lost.
+func scalarCommandToList(cmd string) []interface{} {
+	trimmed := strings.TrimSpace(cmd)
+	if trimmed == "" {
+		return []interface{}{}
+	}
+
+	if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+		var parsed []string
+		if err := json.Unmarshal([]byte(trimmed), &parsed); err == nil {
+			elements := make([]interface{}, 0, len(parsed))
+			for _, p := range parsed {
+				elements = append(elements, p)
+			}
+			return elements
+		}
+	}
+
+	return []interface{}{cmd}
 }
 
 // applyMigrations applies all necessary migrations to bring data to current version

--- a/app/migrations_test.go
+++ b/app/migrations_test.go
@@ -1016,3 +1016,99 @@ func TestMigrateToV11_NoContainerPort(t *testing.T) {
 		t.Errorf("host_port should not be added when container_port is missing")
 	}
 }
+
+// schedTaskCmd returns the container_command of the i-th scheduled task as a []interface{}.
+func schedTaskCmd(t *testing.T, data map[string]interface{}, i int) []interface{} {
+	t.Helper()
+	tasks := data["scheduled_tasks"].([]interface{})
+	task := tasks[i].(map[interface{}]interface{})
+	cmd, ok := task["container_command"].([]interface{})
+	if !ok {
+		t.Fatalf("container_command is not a list: %T (%v)", task["container_command"], task["container_command"])
+	}
+	return cmd
+}
+
+func TestMigrateToV21_WrapsPlainScalar(t *testing.T) {
+	data := map[string]interface{}{
+		"scheduled_tasks": []interface{}{
+			map[interface{}]interface{}{
+				"name":              "a",
+				"container_command": "bun run jobs/x.ts",
+			},
+		},
+	}
+	if err := migrateToV21(data); err != nil {
+		t.Fatalf("migrateToV21: %v", err)
+	}
+	got := schedTaskCmd(t, data, 0)
+	if len(got) != 1 || got[0] != "bun run jobs/x.ts" {
+		t.Errorf("expected single-element list [bun run jobs/x.ts], got %#v", got)
+	}
+}
+
+func TestMigrateToV21_ParsesJSONArrayLiteral(t *testing.T) {
+	data := map[string]interface{}{
+		"scheduled_tasks": []interface{}{
+			map[interface{}]interface{}{
+				"name":              "a",
+				"container_command": `["bun","run","jobs/x.ts"]`,
+			},
+		},
+	}
+	if err := migrateToV21(data); err != nil {
+		t.Fatalf("migrateToV21: %v", err)
+	}
+	got := schedTaskCmd(t, data, 0)
+	want := []interface{}{"bun", "run", "jobs/x.ts"}
+	if len(got) != 3 || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		t.Errorf("expected %#v, got %#v", want, got)
+	}
+}
+
+func TestMigrateToV21_IdempotentOnList(t *testing.T) {
+	data := map[string]interface{}{
+		"scheduled_tasks": []interface{}{
+			map[interface{}]interface{}{
+				"name":              "a",
+				"container_command": []interface{}{"bun", "run", "jobs/x.ts"},
+			},
+		},
+	}
+	for pass := 0; pass < 3; pass++ {
+		if err := migrateToV21(data); err != nil {
+			t.Fatalf("pass %d migrateToV21: %v", pass, err)
+		}
+	}
+	got := schedTaskCmd(t, data, 0)
+	want := []interface{}{"bun", "run", "jobs/x.ts"}
+	if len(got) != 3 || got[0] != want[0] || got[2] != want[2] {
+		t.Errorf("idempotency broken: got %#v", got)
+	}
+}
+
+func TestMigrateToV21_LeavesMissingCommandAbsent(t *testing.T) {
+	data := map[string]interface{}{
+		"scheduled_tasks": []interface{}{
+			map[interface{}]interface{}{
+				"name":     "a",
+				"schedule": "rate(1 hours)",
+			},
+		},
+	}
+	if err := migrateToV21(data); err != nil {
+		t.Fatalf("migrateToV21: %v", err)
+	}
+	tasks := data["scheduled_tasks"].([]interface{})
+	task := tasks[0].(map[interface{}]interface{})
+	if _, exists := task["container_command"]; exists {
+		t.Errorf("container_command should remain absent, got %v", task["container_command"])
+	}
+}
+
+func TestMigrateToV21_NoScheduledTasks(t *testing.T) {
+	data := map[string]interface{}{"project": "x"}
+	if err := migrateToV21(data); err != nil {
+		t.Errorf("migrateToV21 should no-op safely, got %v", err)
+	}
+}

--- a/app/model.go
+++ b/app/model.go
@@ -46,6 +46,11 @@ type Env struct {
 	CloudFrontDistributions []CloudFront `yaml:"cloudfront_distributions,omitempty"`
 	// Custom Extensions (for SNS, SQS, Lambda, etc.)
 	Extensions Extensions `yaml:"extensions,omitempty"`
+	// ManageDNSRecords controls whether Terraform manages Route53 records for Amplify
+	// domains (consumed by the amplify module). Set true only when the Route53 zone
+	// lives in a DIFFERENT AWS account than Amplify (cross-account zone). Optional
+	// pointer: absent = use the amplify module default (false). No migration needed.
+	ManageDNSRecords *bool `yaml:"manage_dns_records,omitempty"`
 }
 
 type AppSync struct {
@@ -85,6 +90,14 @@ type Workload struct {
 	BackendAutoscalingMaxCapacity int32  `yaml:"backend_autoscaling_max_capacity"`
 	BackendCPU                    string `yaml:"backend_cpu"`
 	BackendMemory                 string `yaml:"backend_memory"`
+
+	// Realtime (SSE / streaming) ALB — additive to the API Gateway + Cloud Map path.
+	// When enabled, a dedicated public ALB fronts the backend task for long-lived
+	// SSE connections at realtime.<env>.<domain>. Optional pointers/strings need no
+	// migration: absent = feature off.
+	EnableRealtimeAlb       *bool  `yaml:"enable_realtime_alb,omitempty"`
+	RealtimeSubdomainPrefix string `yaml:"realtime_subdomain_prefix,omitempty"` // default "realtime"
+	RealtimeAlbIdleTimeout  *int   `yaml:"realtime_alb_idle_timeout,omitempty"` // default 300 (seconds)
 }
 
 type S3EnvFile struct {
@@ -201,13 +214,16 @@ type ALB struct {
 
 type ScheduledTask struct {
 	Name                string     `yaml:"name"`
-	Enabled             *bool      `yaml:"enabled,omitempty"` // Schema v20: nil/true = deployed, false = config kept but not deployed
+	Enabled             *bool      `yaml:"enabled,omitempty"`            // Schema v20: nil/true = deployed, false = config kept but not deployed
 	Schedule            string     `yaml:"schedule"`
+	Timezone            string     `yaml:"timezone,omitempty"`           // Schema v21: IANA tz for schedule_expression_timezone (default "UTC")
 	ExternalDockerImage string     `yaml:"docker_image"`
-	ContainerCommand    string     `yaml:"container_command"`
+	ContainerCommand    []string   `yaml:"container_command,omitempty"`  // Schema v21: real list (was scalar string)
 	CPU                 int        `yaml:"cpu,omitempty"`
 	Memory              int        `yaml:"memory,omitempty"`
-	ECRConfig           *ECRConfig `yaml:"ecr_config,omitempty"` // Schema v9
+	MaxRetryAttempts    *int       `yaml:"max_retry_attempts,omitempty"` // Schema v21: EventBridge Scheduler retry_policy (default 3)
+	DLQArn              string     `yaml:"dlq_arn,omitempty"`            // Schema v21: optional dead_letter_config target ARN
+	ECRConfig           *ECRConfig `yaml:"ecr_config,omitempty"`         // Schema v9
 }
 
 // EventBridgeRule defines a single EventBridge rule pattern (Schema v13)

--- a/app/model.go
+++ b/app/model.go
@@ -72,7 +72,14 @@ type Workload struct {
 	BackendEnvVariables        map[string]string `yaml:"backend_env_variables"`
 	Policies                   []string          `yaml:"policies"`
 	BackendPolicies            []Policy          `yaml:"backend_policies"`
-	EnvFilesS3                 []S3EnvFile       `yaml:"env_files_s3"`
+	// Policy holds the backend IAM policy statements consumed by env/main.hbs
+	// ({{#each workload.policy}} -> backend_policy). The yaml mapping is REQUIRED:
+	// without it any typed load->save round-trip (schema migration, web UI save,
+	// profile update) silently dropped the `workload.policy` key from the YAML,
+	// the template then rendered an empty backend_policy, and terraform plan
+	// proposed deleting the backend's custom IAM policy in AWS.
+	Policy     []Policy    `yaml:"policy,omitempty"`
+	EnvFilesS3 []S3EnvFile `yaml:"env_files_s3"`
 
 	SlackWebhook       string   `yaml:"slack_webhook"`
 	EnableGithubOIDC   bool     `yaml:"enable_github_oidc"`
@@ -269,7 +276,9 @@ type Service struct {
 	DesiredCount     int               `yaml:"desired_count"`
 	RemoteAccess     bool              `yaml:"remote_access"`
 	XrayEnabled      bool              `yaml:"xray_enabled"`
-	Essential        bool              `yaml:"essential"`
+	Essential        *bool             `yaml:"essential,omitempty"`         // tri-state: nil = omit (module default), never inject false on round-trip
+	APIDomainPrefix  string            `yaml:"api_domain_prefix,omitempty"` // preserved on round-trip (was silently dropped)
+	HealthCheckPath  string            `yaml:"health_check_path,omitempty"` // preserved on round-trip (was silently dropped)
 	EnvVars          map[string]string `yaml:"env_vars"`
 	EnvVariables     []EnvVariable     `yaml:"env_variables"`
 	EnvFilesS3       []S3EnvFile       `yaml:"env_files_s3"`

--- a/app/model.go
+++ b/app/model.go
@@ -244,11 +244,12 @@ type EventProcessorTask struct {
 	DetailTypes []string `yaml:"detail_types,omitempty"`
 	Sources     []string `yaml:"sources,omitempty"`
 	// Container configuration
-	ExternalDockerImage string     `yaml:"docker_image,omitempty"`
-	ContainerCommand    []string   `yaml:"container_command,omitempty"`
-	CPU                 int        `yaml:"cpu,omitempty"`
-	Memory              int        `yaml:"memory,omitempty"`
-	ECRConfig           *ECRConfig `yaml:"ecr_config,omitempty"` // Schema v9
+	ExternalDockerImage string            `yaml:"docker_image,omitempty"`
+	ContainerCommand    []string          `yaml:"container_command,omitempty"`
+	CPU                 int               `yaml:"cpu,omitempty"`
+	Memory              int               `yaml:"memory,omitempty"`
+	EnvVariables        map[string]string `yaml:"environment_variables,omitempty"` // Declarative non-secret env vars (rendered as custom_env_vars, same mechanism as backend_env_variables)
+	ECRConfig           *ECRConfig        `yaml:"ecr_config,omitempty"`            // Schema v9
 }
 
 type EnvVariable struct {

--- a/app/model.go
+++ b/app/model.go
@@ -213,17 +213,18 @@ type ALB struct {
 }
 
 type ScheduledTask struct {
-	Name                string     `yaml:"name"`
-	Enabled             *bool      `yaml:"enabled,omitempty"`            // Schema v20: nil/true = deployed, false = config kept but not deployed
-	Schedule            string     `yaml:"schedule"`
-	Timezone            string     `yaml:"timezone,omitempty"`           // Schema v21: IANA tz for schedule_expression_timezone (default "UTC")
-	ExternalDockerImage string     `yaml:"docker_image"`
-	ContainerCommand    []string   `yaml:"container_command,omitempty"`  // Schema v21: real list (was scalar string)
-	CPU                 int        `yaml:"cpu,omitempty"`
-	Memory              int        `yaml:"memory,omitempty"`
-	MaxRetryAttempts    *int       `yaml:"max_retry_attempts,omitempty"` // Schema v21: EventBridge Scheduler retry_policy (default 3)
-	DLQArn              string     `yaml:"dlq_arn,omitempty"`            // Schema v21: optional dead_letter_config target ARN
-	ECRConfig           *ECRConfig `yaml:"ecr_config,omitempty"`         // Schema v9
+	Name                string            `yaml:"name"`
+	Enabled             *bool             `yaml:"enabled,omitempty"` // Schema v20: nil/true = deployed, false = config kept but not deployed
+	Schedule            string            `yaml:"schedule"`
+	Timezone            string            `yaml:"timezone,omitempty"` // Schema v21: IANA tz for schedule_expression_timezone (default "UTC")
+	ExternalDockerImage string            `yaml:"docker_image"`
+	ContainerCommand    []string          `yaml:"container_command,omitempty"` // Schema v21: real list (was scalar string)
+	CPU                 int               `yaml:"cpu,omitempty"`
+	Memory              int               `yaml:"memory,omitempty"`
+	MaxRetryAttempts    *int              `yaml:"max_retry_attempts,omitempty"`    // Schema v21: EventBridge Scheduler retry_policy (default 3)
+	DLQArn              string            `yaml:"dlq_arn,omitempty"`               // Schema v21: optional dead_letter_config target ARN
+	EnvVariables        map[string]string `yaml:"environment_variables,omitempty"` // Declarative non-secret env vars (rendered as custom_env_vars, same mechanism as backend_env_variables)
+	ECRConfig           *ECRConfig        `yaml:"ecr_config,omitempty"`            // Schema v9
 }
 
 // EventBridgeRule defines a single EventBridge rule pattern (Schema v13)

--- a/app/raymond_test.go
+++ b/app/raymond_test.go
@@ -196,6 +196,47 @@ func TestHelpers(t *testing.T) {
 			data:     map[string]interface{}{},
 			expected: "",
 		},
+
+		// array helper tests — MUST handle both []string (typed struct data) and
+		// []interface{} (raw YAML via loadEnvToMap/convertToJSONCompatible).
+		// Regression for the backend_policy rendering pipeline in env/main.hbs.
+		{
+			name:     "array: []string renders JSON list",
+			template: `{{{array value}}}`,
+			data:     map[string]interface{}{"value": []string{"s3:GetObject", "s3:PutObject"}},
+			expected: `["s3:GetObject","s3:PutObject"]`,
+		},
+		{
+			name:     "array: []interface{} of strings renders JSON list",
+			template: `{{{array value}}}`,
+			data:     map[string]interface{}{"value": []interface{}{"s3:GetObject", "s3:PutObject", "s3:DeleteObject"}},
+			expected: `["s3:GetObject","s3:PutObject","s3:DeleteObject"]`,
+		},
+		{
+			name:     "array: empty []interface{} renders empty JSON list",
+			template: `{{{array value}}}`,
+			data:     map[string]interface{}{"value": []interface{}{}},
+			expected: `[]`,
+		},
+		{
+			name:     "array: []interface{} of map[interface{}]interface{} (yaml.v2 shape) renders JSON objects",
+			template: `{{{array value}}}`,
+			data: map[string]interface{}{"value": []interface{}{
+				map[interface{}]interface{}{"name": "uploads", "public": true},
+			}},
+			expected: `[{"name":"uploads","public":true}]`,
+		},
+		{
+			name:     "array: nested policy shape inside #each renders actions/resources",
+			template: `{{#each policy}}actions={{{array actions}}} resources={{{array resources}}}{{/each}}`,
+			data: map[string]interface{}{"policy": []interface{}{
+				map[string]interface{}{
+					"actions":   []interface{}{"s3:GetObject"},
+					"resources": []interface{}{"arn:aws:s3:::b", "arn:aws:s3:::b/*"},
+				},
+			}},
+			expected: `actions=["s3:GetObject"] resources=["arn:aws:s3:::b","arn:aws:s3:::b/*"]`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/app/render_policy_cors_test.go
+++ b/app/render_policy_cors_test.go
@@ -1,0 +1,248 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aymerick/raymond"
+)
+
+// policyCorsFixture is a minimal but fully valid env YAML exercising the two
+// regression surfaces of this test file:
+//   - workload.policy -> backend_policy rendering (IAM statements)
+//   - buckets[].cors_rules -> modules/s3 pass-through
+const policyCorsFixture = `
+schema_version: 21
+project: sample
+env: dev
+region: us-east-1
+account_id: "000000000000"
+state_bucket: b
+state_file: state.tfstate
+workload:
+  backend_image_port: 8080
+  backend_health_endpoint: /health
+  github_oidc_subjects: []
+  env_files_s3: []
+  policy:
+  - actions:
+    - s3:GetObject
+    - s3:PutObject
+    - s3:DeleteObject
+    resources:
+    - arn:aws:s3:::sample-uploads-dev
+    - arn:aws:s3:::sample-uploads-dev/*
+buckets:
+- name: uploads
+  public: true
+  versioning: false
+  cors_rules:
+  - allowed_headers:
+    - '*'
+    allowed_methods:
+    - DELETE
+    - GET
+    - HEAD
+    - POST
+    - PUT
+    allowed_origins:
+    - '*'
+    expose_headers:
+    - ETag
+    max_age_seconds: 3600
+- name: plain
+  public: false
+  versioning: true
+services: []
+efs: []
+domain:
+  enabled: false
+postgres:
+  enabled: false
+cognito:
+  enabled: false
+  dashboard_callback_urls: []
+  auto_verified_attributes: []
+ses:
+  enabled: false
+  test_emails: []
+sqs:
+  enabled: false
+alb:
+  enabled: false
+scheduled_tasks: []
+event_processor_tasks: []
+`
+
+// renderMainHbs renders the real env/main.hbs with the same pipeline as
+// deploy.go applyTemplate: loadEnvToMap -> filterDisabledItems -> raymond.
+func renderMainHbs(t *testing.T, yamlPath string) string {
+	t.Helper()
+
+	// raymond keeps helper registration in global state; another test in this
+	// binary may have registered the helpers already and re-registration panics.
+	func() {
+		defer func() { _ = recover() }()
+		registerCustomHelpers()
+	}()
+
+	envMap, err := loadEnvToMap(yamlPath)
+	if err != nil {
+		t.Fatalf("loadEnvToMap: %v", err)
+	}
+	filterDisabledItems(envMap, "services")
+	filterDisabledItems(envMap, "scheduled_tasks")
+	filterDisabledItems(envMap, "event_processor_tasks")
+	envMap["modules"] = "../../infrastructure/modules"
+	envMap["custom_modules"] = "../../custom"
+	envMap["has_custom_pre"] = false
+	envMap["has_custom_post"] = false
+
+	tplBytes, err := os.ReadFile(filepath.Join("..", "env", "main.hbs"))
+	if err != nil {
+		t.Fatalf("read template: %v", err)
+	}
+	tmpl, err := raymond.Parse(string(tplBytes))
+	if err != nil {
+		t.Fatalf("template parse failed: %v", err)
+	}
+	out, err := tmpl.Exec(envMap)
+	if err != nil {
+		t.Fatalf("template exec failed: %v", err)
+	}
+	return out
+}
+
+// assertPolicyRendered asserts the backend_policy block contains the fixture's
+// IAM actions and resources — the exact surface that regressed when
+// workload.policy was dropped and terraform plan proposed deleting the live
+// backend IAM policy.
+func assertPolicyRendered(t *testing.T, out, context string) {
+	t.Helper()
+	for _, want := range []string{
+		`actions = ["s3:GetObject","s3:PutObject","s3:DeleteObject"]`,
+		`resources = ["arn:aws:s3:::sample-uploads-dev","arn:aws:s3:::sample-uploads-dev/*"]`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("%s: rendered output missing %q", context, want)
+		}
+	}
+	if strings.Contains(out, "backend_policy = [\n  ]") {
+		t.Errorf("%s: backend_policy rendered EMPTY", context)
+	}
+}
+
+// TestRenderWorkloadPolicy renders the fixture through the real pipeline and
+// asserts workload.policy materializes as a populated backend_policy block.
+// []interface{} (raw YAML shape) must flow through the array helper intact.
+func TestRenderWorkloadPolicy(t *testing.T) {
+	dir := t.TempDir()
+	yfile := filepath.Join(dir, "dev.yaml")
+	if err := os.WriteFile(yfile, []byte(policyCorsFixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := renderMainHbs(t, yfile)
+	assertPolicyRendered(t, out, "raw yaml render")
+}
+
+// TestRenderBucketCorsRules asserts buckets[].cors_rules pass through the
+// template into the modules/s3 buckets JSON, and that a bucket WITHOUT
+// cors_rules does not gain an explicit empty list (an explicit `"cors_rules":[]`
+// defeats the module's optional default and deletes the live CORS config).
+func TestRenderBucketCorsRules(t *testing.T) {
+	dir := t.TempDir()
+	yfile := filepath.Join(dir, "dev.yaml")
+	if err := os.WriteFile(yfile, []byte(policyCorsFixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := renderMainHbs(t, yfile)
+
+	bucketsLine := extractLineContaining(t, out, "buckets = [")
+	for _, want := range []string{
+		`"allowed_headers":["*"]`,
+		`"allowed_methods":["DELETE","GET","HEAD","POST","PUT"]`,
+		`"allowed_origins":["*"]`,
+		`"expose_headers":["ETag"]`,
+		`"max_age_seconds":3600`,
+	} {
+		if !strings.Contains(bucketsLine, want) {
+			t.Errorf("buckets JSON missing cors rule fragment %q; got:\n%s", want, bucketsLine)
+		}
+	}
+	if strings.Contains(bucketsLine, `"cors_rules":[]`) {
+		t.Errorf("bucket without cors_rules must not render an explicit empty list; got:\n%s", bucketsLine)
+	}
+}
+
+// TestTypedRoundTripPreservesPolicyAndCors is the root-cause regression: a
+// typed Env load->save round-trip (schema migration, web UI save, profile
+// update all take this path) must NOT drop workload.policy from the YAML and
+// must NOT inject `cors_rules: []` into buckets. Before the Workload.Policy
+// field and the BucketConfig omitempty fix, this exact round-trip produced a
+// main.tf with an empty backend_policy and explicit empty cors_rules — and
+// terraform plan proposed deleting the live IAM policy and CORS configs.
+func TestTypedRoundTripPreservesPolicyAndCors(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "dev.yaml"), []byte(policyCorsFixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(wd)
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	e, err := loadEnv("dev")
+	if err != nil {
+		t.Fatalf("typed loadEnv: %v", err)
+	}
+	if err := saveEnv(e); err != nil {
+		t.Fatalf("saveEnv: %v", err)
+	}
+
+	data, err := os.ReadFile("dev.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	roundTripped := string(data)
+	if !strings.Contains(roundTripped, "policy:") {
+		t.Errorf("typed round-trip DROPPED workload.policy from the YAML:\n%s", roundTripped)
+	}
+	if strings.Contains(roundTripped, "cors_rules: []") {
+		t.Errorf("typed round-trip injected explicit empty cors_rules:\n%s", roundTripped)
+	}
+
+	// chdir back so renderMainHbs can resolve ../env/main.hbs.
+	if err := os.Chdir(wd); err != nil {
+		t.Fatal(err)
+	}
+	out := renderMainHbs(t, filepath.Join(dir, "dev.yaml"))
+	assertPolicyRendered(t, out, "post round-trip render")
+
+	bucketsLine := extractLineContaining(t, out, "buckets = [")
+	if !strings.Contains(bucketsLine, `"max_age_seconds":3600`) {
+		t.Errorf("round-trip lost explicit bucket cors_rules; got:\n%s", bucketsLine)
+	}
+	if strings.Contains(bucketsLine, `"cors_rules":[]`) {
+		t.Errorf("round-trip render contains explicit empty cors_rules; got:\n%s", bucketsLine)
+	}
+}
+
+// extractLineContaining returns the first output line containing the marker.
+func extractLineContaining(t *testing.T, out, marker string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, marker) {
+			return line
+		}
+	}
+	t.Fatalf("no line containing %q in render output", marker)
+	return ""
+}

--- a/app/render_sanity_test.go
+++ b/app/render_sanity_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/aymerick/raymond"
+	"gopkg.in/yaml.v2"
+)
+
+func TestUpstreamRenderSanity(t *testing.T) {
+	sample := `
+schema_version: 21
+project: sample
+env: dev
+region: us-east-1
+account_id: "000000000000"
+state_bucket: b
+state_file: state.tfstate
+workload:
+  backend_image_port: 8080
+  backend_health_endpoint: /health
+  github_oidc_subjects: []
+  env_files_s3: []
+  policy: []
+  enable_realtime_alb: true
+  realtime_subdomain_prefix: realtime
+  realtime_alb_idle_timeout: 600
+manage_dns_records: true
+buckets: []
+services: []
+efs: []
+domain:
+  enabled: true
+  domain_name: example.com
+postgres:
+  enabled: false
+cognito:
+  enabled: false
+  dashboard_callback_urls: []
+  auto_verified_attributes: []
+ses:
+  enabled: false
+  test_emails: []
+sqs:
+  enabled: false
+alb:
+  enabled: false
+scheduled_tasks:
+  - name: cleanup
+    schedule: "rate(1 days)"
+    timezone: "Australia/Sydney"
+    container_command: ["bun", "run", "jobs/cleanup.ts"]
+    max_retry_attempts: 5
+    dlq_arn: "arn:aws:sqs:us-east-1:000000000000:sample-dlq"
+    docker_image: "img:latest"
+amplify_apps:
+  - name: portal
+    github_repository: "https://github.com/x/y"
+    branches:
+      - name: main
+`
+	dir := t.TempDir()
+	yfile := filepath.Join(dir, "dev.yaml")
+	if err := os.WriteFile(yfile, []byte(sample), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Register the custom handlebars helpers (array/default/exists/...) exactly as
+	// the real render pipeline does (deploy.go applyTemplate / main.go). raymond keeps
+	// helper registration in global state, so another test in this binary may have
+	// already registered them — registerCustomHelpers panics on a duplicate. Recover
+	// so this test is order-independent and the helpers are guaranteed present.
+	func() {
+		defer func() { _ = recover() }()
+		registerCustomHelpers()
+	}()
+
+	var m map[string]interface{}
+	if err := yaml.Unmarshal([]byte(sample), &m); err != nil {
+		t.Fatal(err)
+	}
+	envMap, ok := convertToJSONCompatible(m).(map[string]interface{})
+	if !ok {
+		t.Fatal("convertToJSONCompatible did not return a map")
+	}
+	// inject modules path placeholder used by template
+	envMap["modules"] = "../modules"
+
+	tplBytes, err := os.ReadFile(filepath.Join("..", "env", "main.hbs"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl, err := raymond.Parse(string(tplBytes))
+	if err != nil {
+		t.Fatalf("template parse failed: %v", err)
+	}
+	out, err := tmpl.Exec(envMap)
+	if err != nil {
+		t.Fatalf("template exec failed: %v", err)
+	}
+
+	checks := []string{
+		`container_command = ["bun","run","jobs/cleanup.ts"]`,
+		`schedule_expression_timezone = "Australia/Sydney"`,
+		`max_retry_attempts = 5`,
+		`dlq_arn = "arn:aws:sqs:us-east-1:000000000000:sample-dlq"`,
+		`enable_realtime_alb = true`,
+		`realtime_subdomain_prefix = "realtime"`,
+		`realtime_alb_idle_timeout = 600`,
+		`manage_dns_records = true`,
+	}
+	for _, c := range checks {
+		if !strings.Contains(out, c) {
+			t.Errorf("rendered output missing expected fragment: %q", c)
+		}
+	}
+	if t.Failed() {
+		t.Logf("---- RENDER OUTPUT (scheduled+amplify excerpt) ----\n%s", out)
+	}
+}

--- a/app/render_sanity_test.go
+++ b/app/render_sanity_test.go
@@ -56,6 +56,12 @@ scheduled_tasks:
     max_retry_attempts: 5
     dlq_arn: "arn:aws:sqs:us-east-1:000000000000:sample-dlq"
     docker_image: "img:latest"
+    environment_variables:
+      FOO: "bar"
+      LOG_LEVEL: "info"
+  - name: noenv
+    schedule: "rate(2 days)"
+    docker_image: "img:latest"
 amplify_apps:
   - name: portal
     github_repository: "https://github.com/x/y"
@@ -117,7 +123,47 @@ amplify_apps:
 			t.Errorf("rendered output missing expected fragment: %q", c)
 		}
 	}
+
+	// Scheduled-task environment_variables -> custom_env_vars (same mechanism as
+	// backend_env_variables). The "cleanup" task declares env vars and MUST render a
+	// custom_env_vars block; the "noenv" task declares none and MUST NOT render one.
+	cleanupBlock := scheduledTaskModuleBlock(t, out, "cleanup")
+	if !strings.Contains(cleanupBlock, "custom_env_vars = [") {
+		t.Errorf("cleanup task missing custom_env_vars block; got:\n%s", cleanupBlock)
+	}
+	for _, kv := range []string{
+		`{ "name" : "FOO", "value" : "bar" }`,
+		`{ "name" : "LOG_LEVEL", "value" : "info" }`,
+	} {
+		if !strings.Contains(cleanupBlock, kv) {
+			t.Errorf("cleanup task custom_env_vars missing entry %q; got:\n%s", kv, cleanupBlock)
+		}
+	}
+
+	noenvBlock := scheduledTaskModuleBlock(t, out, "noenv")
+	if strings.Contains(noenvBlock, "custom_env_vars") {
+		t.Errorf("noenv task must NOT render custom_env_vars; got:\n%s", noenvBlock)
+	}
+
 	if t.Failed() {
 		t.Logf("---- RENDER OUTPUT (scheduled+amplify excerpt) ----\n%s", out)
 	}
+}
+
+// scheduledTaskModuleBlock extracts the rendered `module "schedule_task_<name>" { ... }`
+// block from the template output so assertions can be scoped to one task. The template
+// renders one module per scheduled task as `module "schedule_task_{{name}}"`.
+func scheduledTaskModuleBlock(t *testing.T, out, name string) string {
+	t.Helper()
+	header := `module "schedule_task_` + name + `"`
+	start := strings.Index(out, header)
+	if start < 0 {
+		t.Fatalf("scheduled task module block %q not found in render output", header)
+	}
+	rest := out[start:]
+	// Block ends at the next top-level `module "` declaration or EOF.
+	if next := strings.Index(rest[len(header):], "\nmodule \""); next >= 0 {
+		return rest[:len(header)+next]
+	}
+	return rest
 }

--- a/app/render_sanity_test.go
+++ b/app/render_sanity_test.go
@@ -30,7 +30,8 @@ workload:
   realtime_alb_idle_timeout: 600
 manage_dns_records: true
 buckets: []
-services: []
+services:
+  - name: api
 efs: []
 domain:
   enabled: true
@@ -62,6 +63,19 @@ scheduled_tasks:
   - name: noenv
     schedule: "rate(2 days)"
     docker_image: "img:latest"
+  - name: reuse
+    schedule: "rate(3 days)"
+    ecr_config:
+      mode: use_existing
+      source_service_name: api
+      source_service_type: services
+  - name: pinned
+    schedule: "rate(4 days)"
+    docker_image: "pinned:1.2.3"
+    ecr_config:
+      mode: use_existing
+      source_service_name: api
+      source_service_type: services
 event_processor_tasks:
   - name: notifier
     docker_image: "img:latest"
@@ -133,6 +147,7 @@ amplify_apps:
 		`enable_realtime_alb = true`,
 		`realtime_subdomain_prefix = "realtime"`,
 		`realtime_alb_idle_timeout = 600`,
+		`realtime_parent_domain = module.domain.domain_name`,
 		`manage_dns_records = true`,
 	}
 	for _, c := range checks {
@@ -162,6 +177,32 @@ amplify_apps:
 		t.Errorf("noenv task must NOT render custom_env_vars; got:\n%s", noenvBlock)
 	}
 
+	// ECR use_existing (ecr_config mode "use_existing"): the "reuse" task shares the
+	// "api" service's repository — the module must skip its per-task ECR repo and the
+	// image must resolve from the workloads service ECR map (same precedence as
+	// services.tf: an explicit docker_image wins over the resolved repository).
+	reuseBlock := scheduledTaskModuleBlock(t, out, "reuse")
+	if !strings.Contains(reuseBlock, "create_ecr_repo = false") {
+		t.Errorf("reuse task missing create_ecr_repo = false; got:\n%s", reuseBlock)
+	}
+	if !strings.Contains(reuseBlock, `docker_image = "${module.workloads.service_ecr_url_map["api"]}:latest"`) {
+		t.Errorf("reuse task docker_image not resolved from the source service ECR repo; got:\n%s", reuseBlock)
+	}
+	pinnedBlock := scheduledTaskModuleBlock(t, out, "pinned")
+	if !strings.Contains(pinnedBlock, `docker_image = "pinned:1.2.3"`) {
+		t.Errorf("pinned task must keep its explicit docker_image; got:\n%s", pinnedBlock)
+	}
+	if !strings.Contains(pinnedBlock, "create_ecr_repo = false") {
+		t.Errorf("pinned task missing create_ecr_repo = false; got:\n%s", pinnedBlock)
+	}
+	if strings.Contains(pinnedBlock, "service_ecr_url_map") {
+		t.Errorf("pinned task must NOT resolve docker_image from the ECR map (explicit image wins); got:\n%s", pinnedBlock)
+	}
+	// Feature-off: tasks without ecr_config use_existing render unchanged.
+	if strings.Contains(noenvBlock, "create_ecr_repo") {
+		t.Errorf("noenv task must NOT render create_ecr_repo; got:\n%s", noenvBlock)
+	}
+
 	// Event-processor-task environment_variables -> custom_env_vars (same mechanism,
 	// rendered into the modules/event_bridge_task module which accepts custom_env_vars).
 	// The "notifier" task declares env vars and MUST render a custom_env_vars block; the
@@ -187,6 +228,29 @@ amplify_apps:
 	silentBlock := eventProcessorTaskModuleBlock(t, out, "silent")
 	if strings.Contains(silentBlock, "custom_env_vars") {
 		t.Errorf("silent event task must NOT render custom_env_vars; got:\n%s", silentBlock)
+	}
+	// Feature-off: an event task without container_command renders no command argument
+	// (the event_bridge_task module defaults it to [] and omits the container command).
+	if strings.Contains(silentBlock, "container_command") {
+		t.Errorf("silent event task must NOT render container_command; got:\n%s", silentBlock)
+	}
+
+	// Backward compat: a config WITHOUT enable_realtime_alb renders none of the
+	// realtime wiring (feature-off negative — old configs stay unchanged).
+	// This mutates envMap, so it runs after every assertion on `out`.
+	workloadMap, ok := envMap["workload"].(map[string]interface{})
+	if !ok {
+		t.Fatal("workload map missing from envMap")
+	}
+	delete(workloadMap, "enable_realtime_alb")
+	outOff, err := tmpl.Exec(envMap)
+	if err != nil {
+		t.Fatalf("template exec (realtime off) failed: %v", err)
+	}
+	for _, absent := range []string{"enable_realtime_alb", "realtime_parent_domain"} {
+		if strings.Contains(outOff, absent) {
+			t.Errorf("realtime-off render must not contain %q", absent)
+		}
 	}
 
 	if t.Failed() {

--- a/app/render_sanity_test.go
+++ b/app/render_sanity_test.go
@@ -62,6 +62,23 @@ scheduled_tasks:
   - name: noenv
     schedule: "rate(2 days)"
     docker_image: "img:latest"
+event_processor_tasks:
+  - name: notifier
+    docker_image: "img:latest"
+    container_command: ["bun", "run", "jobs/notify.ts"]
+    rules:
+      - name: invoice-paid
+        sources: ["sample.billing"]
+        detail_types: ["InvoicePaid"]
+    environment_variables:
+      FOO: "bar"
+      LOG_LEVEL: "info"
+  - name: silent
+    docker_image: "img:latest"
+    rules:
+      - name: anything
+        sources: ["sample.x"]
+        detail_types: ["Anything"]
 amplify_apps:
   - name: portal
     github_repository: "https://github.com/x/y"
@@ -145,6 +162,33 @@ amplify_apps:
 		t.Errorf("noenv task must NOT render custom_env_vars; got:\n%s", noenvBlock)
 	}
 
+	// Event-processor-task environment_variables -> custom_env_vars (same mechanism,
+	// rendered into the modules/event_bridge_task module which accepts custom_env_vars).
+	// The "notifier" task declares env vars and MUST render a custom_env_vars block; the
+	// "silent" task declares none and MUST NOT render one.
+	notifierBlock := eventProcessorTaskModuleBlock(t, out, "notifier")
+	if !strings.Contains(notifierBlock, "custom_env_vars = [") {
+		t.Errorf("notifier event task missing custom_env_vars block; got:\n%s", notifierBlock)
+	}
+	for _, kv := range []string{
+		`{ "name" : "FOO", "value" : "bar" }`,
+		`{ "name" : "LOG_LEVEL", "value" : "info" }`,
+	} {
+		if !strings.Contains(notifierBlock, kv) {
+			t.Errorf("notifier event task custom_env_vars missing entry %q; got:\n%s", kv, notifierBlock)
+		}
+	}
+	// container_command on an event task must render as a valid HCL list (regression:
+	// it previously rendered the raw []string via {{{container_command}}}, now uses {{{array}}}).
+	if !strings.Contains(notifierBlock, `container_command = ["bun","run","jobs/notify.ts"]`) {
+		t.Errorf("notifier event task container_command not rendered as HCL list; got:\n%s", notifierBlock)
+	}
+
+	silentBlock := eventProcessorTaskModuleBlock(t, out, "silent")
+	if strings.Contains(silentBlock, "custom_env_vars") {
+		t.Errorf("silent event task must NOT render custom_env_vars; got:\n%s", silentBlock)
+	}
+
 	if t.Failed() {
 		t.Logf("---- RENDER OUTPUT (scheduled+amplify excerpt) ----\n%s", out)
 	}
@@ -159,6 +203,24 @@ func scheduledTaskModuleBlock(t *testing.T, out, name string) string {
 	start := strings.Index(out, header)
 	if start < 0 {
 		t.Fatalf("scheduled task module block %q not found in render output", header)
+	}
+	rest := out[start:]
+	// Block ends at the next top-level `module "` declaration or EOF.
+	if next := strings.Index(rest[len(header):], "\nmodule \""); next >= 0 {
+		return rest[:len(header)+next]
+	}
+	return rest
+}
+
+// eventProcessorTaskModuleBlock extracts the rendered `module "event_bus_task_<name>" { ... }`
+// block from the template output so assertions can be scoped to one event-processor task.
+// The template renders one module per event-processor task as `module "event_bus_task_{{name}}"`.
+func eventProcessorTaskModuleBlock(t *testing.T, out, name string) string {
+	t.Helper()
+	header := `module "event_bus_task_` + name + `"`
+	start := strings.Index(out, header)
+	if start < 0 {
+		t.Fatalf("event processor task module block %q not found in render output", header)
 	}
 	rest := out[start:]
 	// Block ends at the next top-level `module "` declaration or EOF.

--- a/env/main.hbs
+++ b/env/main.hbs
@@ -516,6 +516,10 @@ module "workloads" {
   enable_realtime_alb = true
   realtime_subdomain_prefix = "{{default workload.realtime_subdomain_prefix "realtime"}}"
   realtime_alb_idle_timeout = {{default workload.realtime_alb_idle_timeout 300}}
+  {{#if domain.enabled}}
+  # Hostname parent = the domain module's actual zone (env-prefixed only when the module prefixes)
+  realtime_parent_domain = module.domain.domain_name
+  {{/if}}
   {{/if}}
   {{#compare (len services) ">" 0}}
   services = {{{array services}}} 
@@ -559,6 +563,21 @@ module "schedule_task_{{name}}" {
   task = "{{name}}"
   {{#if docker_image}}
   docker_image = "{{docker_image}}"
+  {{/if}}
+  {{#if (eq ecr_config.mode "use_existing")}}
+  # ecr_config mode "use_existing": reuse the source's ECR repository, skip the per-task one
+  create_ecr_repo = false
+  {{#unless docker_image}}
+  {{#if (eq ecr_config.source_service_type "services")}}
+  docker_image = "${module.workloads.service_ecr_url_map["{{ecr_config.source_service_name}}"]}:latest"
+  {{/if}}
+  {{#if (eq ecr_config.source_service_type "scheduled_tasks")}}
+  docker_image = "${module.schedule_task_{{ecr_config.source_service_name}}.ecr_repo_url}:latest"
+  {{/if}}
+  {{#if (eq ecr_config.source_service_type "event_processor_tasks")}}
+  docker_image = "${module.event_bus_task_{{ecr_config.source_service_name}}.ecr_repo_url}:latest"
+  {{/if}}
+  {{/unless}}
   {{/if}}
   {{#if container_command}}
   container_command = {{{array container_command}}}

--- a/env/main.hbs
+++ b/env/main.hbs
@@ -631,7 +631,7 @@ module "event_bus_task_{{name}}" {
   docker_image = "{{docker_image}}"
   {{/if}}
   {{#if container_command}}
-  container_command = {{{ container_command }}}
+  container_command = {{{array container_command}}}
   {{/if}}
   subnet_ids = local.subnet_ids
   vpc_id     = local.vpc_id

--- a/env/main.hbs
+++ b/env/main.hbs
@@ -511,6 +511,12 @@ module "workloads" {
   alb_arn = module.alb.alb_arn
   enable_alb = true
   {{/if}}{{/if}}
+  {{#if workload.enable_realtime_alb}}
+  # Realtime (SSE / streaming) ALB — additive to API Gateway + Cloud Map
+  enable_realtime_alb = true
+  realtime_subdomain_prefix = "{{default workload.realtime_subdomain_prefix "realtime"}}"
+  realtime_alb_idle_timeout = {{default workload.realtime_alb_idle_timeout 300}}
+  {{/if}}
   {{#compare (len services) ">" 0}}
   services = {{{array services}}} 
   {{/compare}}
@@ -555,7 +561,7 @@ module "schedule_task_{{name}}" {
   docker_image = "{{docker_image}}"
   {{/if}}
   {{#if container_command}}
-  container_command = {{{ container_command }}}
+  container_command = {{{array container_command}}}
   {{/if}}
   {{#if cpu}}
   cpu = {{cpu}}
@@ -565,6 +571,15 @@ module "schedule_task_{{name}}" {
   {{/if}}
   # https://docs.aws.amazon.com/scheduler/latest/UserGuide/schedule-types.html?icmpid=docs_console_unmapped#rate-based
   schedule = "{{schedule}}"
+  {{#if timezone}}
+  schedule_expression_timezone = "{{timezone}}"
+  {{/if}}
+  {{#if (exists max_retry_attempts)}}
+  max_retry_attempts = {{max_retry_attempts}}
+  {{/if}}
+  {{#if dlq_arn}}
+  dlq_arn = "{{dlq_arn}}"
+  {{/if}}
   subnet_ids = local.subnet_ids
   vpc_id     = local.vpc_id
   cluster = module.workloads.ecr_cluster.arn
@@ -832,6 +847,10 @@ module "amplify" {
   # Route53 zone ID for creating DNS records (ACM validation + subdomain CNAME)
   {{#if domain.enabled}}
   zone_id = module.domain.zone_id
+  {{/if}}
+  {{#if (exists manage_dns_records)}}
+  # Whether Terraform manages Route53 records for Amplify domains (cross-account zone)
+  manage_dns_records = {{manage_dns_records}}
   {{/if}}
 
   amplify_apps = [

--- a/modules/domain/outputs.tf
+++ b/modules/domain/outputs.tf
@@ -19,3 +19,8 @@ output "enable_custom_domain" {
   value       = true
 }
 
+output "domain_name" {
+  description = "The zone/hostname this module actually created — env-prefixed only when add_env_domain_prefix is true"
+  value       = local.domain_name
+}
+

--- a/modules/ecs_task/iam.tf
+++ b/modules/ecs_task/iam.tf
@@ -119,6 +119,25 @@ resource "aws_iam_role_policy_attachment" "scheduler_ecs_full_access" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonECS_FullAccess"
 }
 
+# Allow the scheduler to deliver failed invocations to the configured dead-letter queue.
+# Only created when a DLQ ARN is provided; zero impact otherwise.
+resource "aws_iam_role_policy" "scheduler_dlq_send" {
+  count = var.dlq_arn != "" ? 1 : 0
+  name  = "SchedulerDLQSend_${var.project}_task_${var.task}_${var.env}"
+  role  = aws_iam_role.scheduler_role.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["sqs:SendMessage"]
+        Resource = [var.dlq_arn]
+      }
+    ]
+  })
+}
+
 
 resource "aws_iam_role_policy_attachment" "sqs_access" {
   count      = var.sqs_enable == true ? 1 : 0

--- a/modules/ecs_task/main.tf
+++ b/modules/ecs_task/main.tf
@@ -20,11 +20,23 @@ resource "aws_scheduler_schedule" "scheduler" {
     mode = "OFF"
   }
 
-  schedule_expression = var.schedule
+  schedule_expression          = var.schedule
+  schedule_expression_timezone = var.schedule_expression_timezone
 
   target {
     arn      = var.cluster
     role_arn = aws_iam_role.scheduler_role.arn
+
+    retry_policy {
+      maximum_retry_attempts = var.max_retry_attempts
+    }
+
+    dynamic "dead_letter_config" {
+      for_each = var.dlq_arn != "" ? [var.dlq_arn] : []
+      content {
+        arn = dead_letter_config.value
+      }
+    }
 
     ecs_parameters {
       task_definition_arn    = aws_ecs_task_definition.task.arn_without_revision
@@ -77,12 +89,12 @@ resource "aws_ecs_task_definition" "task" {
 
   container_definitions = jsonencode([merge(
     {
-      name      = "${var.project}_container_${var.task}_${var.env}"
-      cpu       = var.cpu
-      memory    = var.memory
-      image     = local.docker_image
-      secrets   = local.task_env_ssm
-      essential = true
+      name        = "${var.project}_container_${var.task}_${var.env}"
+      cpu         = var.cpu
+      memory      = var.memory
+      image       = local.docker_image
+      secrets     = local.task_env_ssm
+      essential   = true
       Environment = local.environment_variables
 
       logConfiguration = {

--- a/modules/ecs_task/main.tf
+++ b/modules/ecs_task/main.tf
@@ -54,7 +54,7 @@ resource "aws_scheduler_schedule" "scheduler" {
 
 resource "aws_ecr_repository" "task" {
   name         = "${var.project}_task_${var.task}"
-  count        = var.env == "dev" ? 1 : 0
+  count        = var.env == "dev" && var.create_ecr_repo ? 1 : 0
   force_delete = true
 
   tags = {
@@ -75,7 +75,7 @@ locals {
 resource "aws_ecr_repository_policy" "task" {
   repository = join("", aws_ecr_repository.task.*.name)
   policy     = data.aws_iam_policy_document.default_ecr_policy.json
-  count      = var.env == "dev" ? 1 : 0
+  count      = var.env == "dev" && var.create_ecr_repo ? 1 : 0
 }
 
 resource "aws_ecs_task_definition" "task" {

--- a/modules/ecs_task/outputs.tf
+++ b/modules/ecs_task/outputs.tf
@@ -1,0 +1,4 @@
+output "ecr_repo_url" {
+  description = "Repository URL this task's image comes from (per-task ECR repo in dev, var.ecr_url otherwise). Used by ecr_config mode \"use_existing\" consumers."
+  value       = local.ecr_image
+}

--- a/modules/ecs_task/variable.tf
+++ b/modules/ecs_task/variable.tf
@@ -38,6 +38,29 @@ variable "schedule" {
   default = "rate(1 days)"
 }
 
+# IANA timezone for the schedule expression (e.g. "Australia/Sydney" for DST-aware local runs).
+# https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-schedule-scheduleexpressiontimezone.html
+variable "schedule_expression_timezone" {
+  description = "IANA timezone the schedule expression is evaluated in (DST-aware)"
+  type        = string
+  default     = "UTC"
+}
+
+# EventBridge Scheduler retry policy for the ECS RunTask target.
+# https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-schedule-retries.html
+variable "max_retry_attempts" {
+  description = "Maximum number of retry attempts for the schedule target invocation"
+  type        = number
+  default     = 3
+}
+
+# Optional dead-letter queue ARN for events the scheduler fails to deliver after retries.
+variable "dlq_arn" {
+  description = "SQS queue ARN to use as the schedule target dead-letter destination (empty = disabled)"
+  type        = string
+  default     = ""
+}
+
 variable "subnet_ids" {
   type = list(string)
 }
@@ -55,7 +78,7 @@ variable "sqs_policy_arn" {
 }
 
 variable "sqs_queue_url" {
-  default =  ""
+  default = ""
 }
 
 variable "sqs_enable" {

--- a/modules/ecs_task/variable.tf
+++ b/modules/ecs_task/variable.tf
@@ -26,6 +26,14 @@ variable "docker_image" {
   default = ""
 }
 
+# Set false when the task reuses another service's image (ecr_config mode
+# "use_existing") so no orphan per-task repository is created.
+variable "create_ecr_repo" {
+  description = "Whether to create the per-task ECR repository (dev env only). Set false when the image comes from an existing repository."
+  type        = bool
+  default     = true
+}
+
 variable "container_command" {
   type    = list(string)
   default = []

--- a/modules/event_bridge_task/ecs.tf
+++ b/modules/event_bridge_task/ecs.tf
@@ -37,25 +37,27 @@ resource "aws_ecs_task_definition" "task" {
   execution_role_arn       = aws_iam_role.task_execution.arn
   task_role_arn            = aws_iam_role.task.arn
 
-  container_definitions = jsonencode([{
-    name      = "${var.project}_container_${var.task}_${var.env}"
-    cpu       = 256
-    memory    = 512
-    image     = local.docker_image
-    secrets   = local.task_env_ssm
-    essential = true
-    environment = local.environment_variables
+  container_definitions = jsonencode([merge(
+    {
+      name        = "${var.project}_container_${var.task}_${var.env}"
+      cpu         = 256
+      memory      = 512
+      image       = local.docker_image
+      secrets     = local.task_env_ssm
+      essential   = true
+      environment = local.environment_variables
 
-    logConfiguration = {
-      logDriver = "awslogs"
-      options = {
-        awslogs-group         = aws_cloudwatch_log_group.task.name
-        awslogs-stream-prefix = "ecs"
-        awslogs-region        = data.aws_region.current.name
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.task.name
+          awslogs-stream-prefix = "ecs"
+          awslogs-region        = data.aws_region.current.name
+        }
       }
-    }
-
-  }])
+    },
+    length(var.container_command) > 0 ? { command = var.container_command } : {}
+  )])
 
   tags = {
     Name        = "${var.project}-task-${var.task}-${var.env}"

--- a/modules/event_bridge_task/outputs.tf
+++ b/modules/event_bridge_task/outputs.tf
@@ -1,0 +1,4 @@
+output "ecr_repo_url" {
+  description = "Repository URL this task's image comes from (per-task ECR repo in dev, var.ecr_url otherwise). Used by ecr_config mode \"use_existing\" consumers."
+  value       = local.ecr_image
+}

--- a/modules/event_bridge_task/variables.tf
+++ b/modules/event_bridge_task/variables.tf
@@ -25,6 +25,12 @@ variable "docker_image" {
   default = ""
 }
 
+variable "container_command" {
+  description = "Optional container command override (exec form). Empty list = use the image's default CMD."
+  type        = list(string)
+  default     = []
+}
+
 variable "subnet_ids" {
   type = list(string)
 }

--- a/modules/workloads/backend.tf
+++ b/modules/workloads/backend.tf
@@ -1,5 +1,13 @@
 locals {
   backend_name = "${var.project}_service_${var.env}"
+
+  # Target groups the backend ECS service registers with. Additive: the API
+  # Gateway + Cloud Map path stays intact; enable_alb adds the standard ALB TG,
+  # enable_realtime_alb adds the realtime/SSE ALB TG. A task can be in both.
+  backend_target_group_arns = concat(
+    var.enable_alb ? [aws_lb_target_group.backend[0].arn] : [],
+    var.enable_realtime_alb ? [aws_lb_target_group.realtime[0].arn] : [],
+  )
 }
 
 data "aws_vpc" "selected" {
@@ -25,18 +33,20 @@ resource "aws_ecs_service" "backend" {
   }
 
   dynamic "load_balancer" {
-    for_each = var.enable_alb ? [1] : []
+    for_each = local.backend_target_group_arns
     content {
-      target_group_arn = aws_lb_target_group.backend[0].arn
+      target_group_arn = load_balancer.value
       container_name   = local.backend_name
       container_port   = var.backend_image_port
     }
   }
 
-  # Use service_registries with explicitly created Cloud Map service
-  # This allows API Gateway to reference the service ARN directly
+  # Use service_registries with explicitly created Cloud Map service.
+  # This allows API Gateway to reference the service ARN directly.
+  # Kept for every mode except enable_alb, so enable_realtime_alb retains
+  # Cloud Map + API Gateway while ALSO adding the realtime ALB.
   dynamic "service_registries" {
-    for_each = var.enable_alb ? [] : [1] # Only when using API Gateway
+    for_each = var.enable_alb ? [] : [1] # API Gateway / Cloud Map path (incl. enable_realtime_alb)
     content {
       registry_arn   = aws_service_discovery_service.backend[0].arn
       container_name = local.backend_name
@@ -190,6 +200,18 @@ resource "aws_security_group" "backend" {
       to_port         = var.backend_image_port
       security_groups = [aws_security_group.alb[0].id]
       description     = "Allow traffic from ALB"
+    }
+  }
+
+  # Allow traffic from the realtime/SSE ALB if enabled
+  dynamic "ingress" {
+    for_each = var.enable_realtime_alb ? [1] : []
+    content {
+      protocol        = "tcp"
+      from_port       = var.backend_image_port
+      to_port         = var.backend_image_port
+      security_groups = [aws_security_group.realtime_alb[0].id]
+      description     = "Allow traffic from realtime ALB"
     }
   }
 

--- a/modules/workloads/realtime_alb.tf
+++ b/modules/workloads/realtime_alb.tf
@@ -1,0 +1,163 @@
+# Realtime (SSE / streaming) ALB — Option A.
+#
+# Additive, gated on var.enable_realtime_alb. When enabled, a dedicated public
+# Application Load Balancer is created in front of the backend ECS task for
+# long-lived SSE / streaming connections, with a large idle timeout. The
+# existing API Gateway + Cloud Map path is left fully intact — the backend task
+# is registered with BOTH this target group AND Cloud Map (see backend.tf).
+#
+# The realtime hostname is <realtime_subdomain_prefix>.<env>.<domain> (e.g.
+# realtime.dev.example.com), covered by the wildcard certificate
+# *.<env>.<domain> from the domain module (var.subdomains_certificate_arn).
+
+locals {
+  # The domain module creates the Route53 zone as "<env>.<domain>" (env-prefixed)
+  # and var.domain_zone_id points at that zone. var.domain is the root
+  # (e.g. example.com), so the env-qualified domain is "<env>.<domain>".
+  realtime_env_domain  = "${var.env}.${var.domain}"
+  realtime_full_domain = "${var.realtime_subdomain_prefix}.${local.realtime_env_domain}"
+}
+
+resource "aws_lb" "realtime" {
+  count = var.enable_realtime_alb ? 1 : 0
+
+  name               = "${var.project}-realtime-${var.env}"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.realtime_alb[0].id]
+  subnets            = var.subnet_ids
+  idle_timeout       = var.realtime_alb_idle_timeout
+
+  tags = {
+    Name        = "${var.project}-realtime-${var.env}"
+    Environment = var.env
+    Project     = var.project
+    ManagedBy   = "meroku"
+    terraform   = "true"
+    Application = "${var.project}-${var.env}"
+  }
+}
+
+resource "aws_security_group" "realtime_alb" {
+  count = var.enable_realtime_alb ? 1 : 0
+
+  name   = "${var.project}_realtime_alb_${var.env}"
+  vpc_id = var.vpc_id
+
+  ingress {
+    protocol         = "tcp"
+    from_port        = 443
+    to_port          = 443
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+    description      = "Allow HTTPS from anywhere"
+  }
+
+  ingress {
+    protocol         = "tcp"
+    from_port        = 80
+    to_port          = 80
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+    description      = "Allow HTTP from anywhere (redirected to HTTPS)"
+  }
+
+  egress {
+    protocol         = "-1"
+    from_port        = 0
+    to_port          = 0
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  tags = {
+    Name        = "${var.project}_realtime_alb_${var.env}"
+    Environment = var.env
+    Project     = var.project
+    ManagedBy   = "meroku"
+    terraform   = "true"
+    Application = "${var.project}-${var.env}"
+  }
+}
+
+resource "aws_lb_target_group" "realtime" {
+  count = var.enable_realtime_alb ? 1 : 0
+
+  name                 = "${var.project}-realtime-tg-${var.env}"
+  port                 = var.backend_image_port
+  protocol             = "HTTP"
+  protocol_version     = "HTTP1"
+  vpc_id               = var.vpc_id
+  target_type          = "ip"
+  deregistration_delay = 30
+
+  dynamic "health_check" {
+    for_each = var.backend_health_endpoint != "" ? [1] : []
+    content {
+      path                = var.backend_health_endpoint
+      interval            = 30
+      timeout             = 5
+      healthy_threshold   = 2
+      unhealthy_threshold = 2
+      matcher             = "200"
+    }
+  }
+
+  # No stickiness: SSE connections are pinned for their lifetime to whichever
+  # task accepted them; round-robin spreads new connections across tasks.
+
+  tags = {
+    Name        = "${var.project}-realtime-tg-${var.env}"
+    Environment = var.env
+    Project     = var.project
+    ManagedBy   = "meroku"
+    terraform   = "true"
+    Application = "${var.project}-${var.env}"
+  }
+}
+
+resource "aws_lb_listener" "realtime_https" {
+  count = var.enable_realtime_alb ? 1 : 0
+
+  load_balancer_arn = aws_lb.realtime[0].arn
+  port              = 443
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  certificate_arn   = var.subdomains_certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.realtime[0].arn
+  }
+}
+
+resource "aws_lb_listener" "realtime_http" {
+  count = var.enable_realtime_alb ? 1 : 0
+
+  load_balancer_arn = aws_lb.realtime[0].arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}
+
+resource "aws_route53_record" "realtime_alias" {
+  count = var.enable_realtime_alb ? 1 : 0
+
+  zone_id = var.domain_zone_id
+  name    = local.realtime_full_domain
+  type    = "A"
+
+  alias {
+    name                   = aws_lb.realtime[0].dns_name
+    zone_id                = aws_lb.realtime[0].zone_id
+    evaluate_target_health = true
+  }
+}

--- a/modules/workloads/realtime_alb.tf
+++ b/modules/workloads/realtime_alb.tf
@@ -6,16 +6,19 @@
 # existing API Gateway + Cloud Map path is left fully intact — the backend task
 # is registered with BOTH this target group AND Cloud Map (see backend.tf).
 #
-# The realtime hostname is <realtime_subdomain_prefix>.<env>.<domain> (e.g.
-# realtime.dev.example.com), covered by the wildcard certificate
-# *.<env>.<domain> from the domain module (var.subdomains_certificate_arn).
+# The realtime hostname is <realtime_subdomain_prefix>.<domain-module zone>
+# (e.g. realtime.dev.example.com on env-prefixed setups, realtime.example.com
+# on prod where add_env_domain_prefix = false), covered by the wildcard
+# certificate *.<zone> from the domain module (var.subdomains_certificate_arn).
 
 locals {
-  # The domain module creates the Route53 zone as "<env>.<domain>" (env-prefixed)
-  # and var.domain_zone_id points at that zone. var.domain is the root
-  # (e.g. example.com), so the env-qualified domain is "<env>.<domain>".
-  realtime_env_domain  = "${var.env}.${var.domain}"
-  realtime_full_domain = "${var.realtime_subdomain_prefix}.${local.realtime_env_domain}"
+  # Parent domain for the realtime hostname. Preferred source: the domain
+  # module's actual zone name via var.realtime_parent_domain (env-prefixed only
+  # when the domain module prefixes — prod sets add_env_domain_prefix = false).
+  # Fallback keeps the legacy "<env>.<domain>" derivation for callers that do
+  # not pass the variable.
+  realtime_parent_domain = coalesce(var.realtime_parent_domain, "${var.env}.${var.domain}")
+  realtime_full_domain   = "${var.realtime_subdomain_prefix}.${local.realtime_parent_domain}"
 }
 
 resource "aws_lb" "realtime" {

--- a/modules/workloads/variables.tf
+++ b/modules/workloads/variables.tf
@@ -311,6 +311,12 @@ variable "realtime_alb_idle_timeout" {
   default     = 300
 }
 
+variable "realtime_parent_domain" {
+  description = "Parent domain for the realtime hostname — the domain module's actual zone name (env-prefixed only when the module prefixes). Empty = legacy \"<env>.<domain>\" derivation."
+  type        = string
+  default     = ""
+}
+
 
 variable "backend_remote_access" {
   type    = bool

--- a/modules/workloads/variables.tf
+++ b/modules/workloads/variables.tf
@@ -290,6 +290,27 @@ variable "enable_alb" {
   default     = false
 }
 
+# Realtime (SSE / streaming) ALB — Option A.
+# Additive to the API Gateway + Cloud Map path; when enabled the backend task
+# is fronted by a dedicated public ALB for long-lived SSE connections.
+variable "enable_realtime_alb" {
+  description = "Enable a dedicated public ALB for realtime/SSE traffic in front of the backend task"
+  type        = bool
+  default     = false
+}
+
+variable "realtime_subdomain_prefix" {
+  description = "Subdomain prefix for the realtime ALB hostname (realtime.<env>.<domain>)"
+  type        = string
+  default     = "realtime"
+}
+
+variable "realtime_alb_idle_timeout" {
+  description = "Idle timeout (seconds) for the realtime ALB — large enough to hold SSE connections between heartbeats"
+  type        = number
+  default     = 300
+}
+
 
 variable "backend_remote_access" {
   type    = bool

--- a/receipts/examples/dev.yaml
+++ b/receipts/examples/dev.yaml
@@ -61,6 +61,10 @@ scheduled_tasks:
     container_command: ["bun", "run", "jobs/cleanup.ts"]
     environment_variables: # non-secret env, same mechanism as backend_env_variables; secrets go in SSM /<env>/<project>/task/<name>/*
       LOG_LEVEL: info
+    ecr_config: # reuse the aichat service's ECR image (no per-task repository is created)
+      mode: use_existing
+      source_service_name: aichat
+      source_service_type: services
 sqs:
   enabled: true
   name: main

--- a/receipts/examples/dev.yaml
+++ b/receipts/examples/dev.yaml
@@ -55,10 +55,25 @@ scheduled_tasks:
     docker_image: ""
     container_command: '["fees"]'
     allow_public_access: true
+  - name: cleanup
+    schedule: "cron(0 2 * * ? *)"
+    docker_image: ""
+    container_command: ["bun", "run", "jobs/cleanup.ts"]
+    environment_variables: # non-secret env, same mechanism as backend_env_variables; secrets go in SSM /<env>/<project>/task/<name>/*
+      LOG_LEVEL: info
 sqs:
   enabled: true
   name: main
-event_processor_tasks: []
+event_processor_tasks:
+  - name: notifier
+    docker_image: ""
+    container_command: ["bun", "run", "jobs/notify.ts"]
+    rules:
+      - name: invoice-paid
+        sources: ["caremaster.billing"]
+        detail_types: ["InvoicePaid"]
+    environment_variables: # non-secret env, same mechanism as backend_env_variables; secrets go in SSM /<env>/<project>/task/<name>/*
+      LOG_LEVEL: info
 pubsub_appsync:
   enabled: true
   schema: true


### PR DESCRIPTION
## What & why
Upstreams three infra features that currently live as **force-tracked overrides** in `caremaster-infrastructure`, generalized into proper meroku features (driven by `dev.yaml`). After this merges, caremaster can drop its forks and configure everything via `dev.yaml`.

## Features
### 1. Scheduled ECS jobs (cron) — fix + harden
- `app/model.go`: `ScheduledTask.ContainerCommand` `string` → `[]string`; add `Timezone`, `MaxRetryAttempts`, `DLQArn`.
- `app/migrations.go` (+tests): **migration v21** converts a scalar `container_command` to a single-element list (idempotent, safe on missing/already-list).
- `modules/ecs_task/*`: `schedule_expression_timezone`, `retry_policy` (`max_retry_attempts`), optional `dead_letter_config` + scoped `sqs:SendMessage` IAM.
- `env/main.hbs`: scheduled block now uses `{{{array container_command}}}` (was raw → produced broken HCL for a list) + timezone/retry/DLQ passthroughs.

### 2. Realtime / SSE ALB
- New `modules/workloads/realtime_alb.tf`; `backend.tf` adds the realtime target group (concat with the standard ALB), the realtime-ALB security-group ingress, and retains Cloud Map / API Gateway when realtime ALB is enabled.
- `modules/workloads/variables.tf`: `enable_realtime_alb`, `realtime_subdomain_prefix`, `realtime_alb_idle_timeout`; `app/model.go` workload fields + `env/main.hbs` passthrough.

### 3. Amplify DNS management
- `app/model.go` `Env.ManageDNSRecords`; `env/main.hbs` passes `manage_dns_records` to the amplify module. The consuming Route53 resources already exist in `modules/amplify/` — this only wires the toggle.

## Verification
- `go build ./...`, `go vet ./...`, `go test ./...` → all pass (incl. 5 new v21 migration tests + a render-pipeline sanity test asserting all 3 features render).
- `terraform fmt` clean; `terraform validate` OK on `modules/ecs_task` and `modules/workloads`.

## Notes
- Schema version bumped 20 → 21.
- Follow-up (not in this PR): event-processor `container_command` (`env/main.hbs:634`) has the same raw-vs-`{{{array}}}` list mismatch and should get the same fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
