### PR TITLE
ci: build the web app, and add the ALB outputs main.hbs already used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ env:
   # app: 1.23.0), so both are built with a toolchain each accepts.
   GO_VERSION: '1.23'
   TERRAFORM_VERSION: '1.9.8'
+  # Matches release.yml. The pnpm version is deliberately not pinned here — the
+  # web job reads it from web/package.json's `packageManager` instead.
+  NODE_VERSION: '20'
 
 jobs:
   go:
@@ -140,3 +143,55 @@ jobs:
       - name: Check the golden capture against terraform
         run: go test -tags tfgolden ./internal/boundary/ -count=1
         working-directory: modules/workloads/ci_lambda
+
+  # The web app was not compiled anywhere until a tag was pushed: release.yml ran
+  # `pnpm build` and this workflow covered only Go and Terraform. So the first
+  # signal that the frontend no longer compiled was a failed release, which is
+  # exactly what happened to v4.0.0 — a type error in a component broke the
+  # release build after the PR had already merged green.
+  #
+  # It runs `pnpm build`, the same script release.yml runs, rather than a
+  # hand-rolled equivalent. That matters: `pnpm build` is `tsc -b && vite build`,
+  # and `tsc -b` is stricter than the `tsc --noEmit -p tsconfig.json` you would
+  # reach for by hand — the error that broke v4.0.0 passes the latter and fails
+  # the former. Anything less than the real command reproduces the same gap in a
+  # smaller form.
+  web:
+    name: Web
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # No version here on purpose. pnpm/action-setup reads `packageManager`
+      # from web/package.json when none is given, so this does not become a
+      # third place the pnpm version has to be kept in sync.
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+          cache-dependency-path: web/pnpm-lock.yaml
+
+      # --frozen-lockfile, matching release.yml: a lockfile that does not satisfy
+      # package.json should fail here rather than resolve to something the
+      # release will not reproduce.
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      # Build only. `biome ci src` reports 40 errors on the tree as it stands —
+      # 21 useButtonType, 12 noLabelWithoutControl, the rest a11y and unused
+      # imports — none of them from this change. Gating on it would make every
+      # PR red for reasons unrelated to itself, and the obvious sweep is not
+      # safe: a <button> inside a form defaults to type="submit", so adding
+      # type="button" to all 21 changes behaviour in whichever ones were
+      # submitting. Clearing those is its own change with its own review, and
+      # this step turns into `pnpm exec biome ci src` when it lands.
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,11 +166,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # No version here on purpose. pnpm/action-setup reads `packageManager`
-      # from web/package.json when none is given, so this does not become a
-      # third place the pnpm version has to be kept in sync.
+      # No version here on purpose: the action reads `packageManager` from the
+      # package.json it is pointed at, so the pnpm version does not become a
+      # third place to keep in sync.
+      #
+      # package_json_file is required. `defaults.run.working-directory` above
+      # applies to `run` steps only, not to action inputs, so without this the
+      # action looks in the repository root — which has no package.json — and
+      # fails with "No pnpm version is specified".
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/modules/workloads/outputs.tf
+++ b/modules/workloads/outputs.tf
@@ -59,3 +59,20 @@ output "api_gateway_custom_domain_enabled" {
   value       = var.enable_custom_domain
 }
 
+# env/main.hbs has always emitted `domain_name = module.workloads.alb_dns_name`
+# for a CloudFront distribution with an origin of type "alb", and this module has
+# never had that output. Any config combining CloudFront with an ALB origin
+# therefore failed to plan on "Unsupported attribute" — invisible until someone
+# wrote that exact combination, which is why it survived.
+#
+# Empty when the ALB is off, since the data source it reads is not created then.
+output "alb_dns_name" {
+  description = "DNS name of the ALB, for use as a CloudFront origin. Empty when the ALB is disabled."
+  value       = length(data.aws_lb.alb) > 0 ? data.aws_lb.alb[0].dns_name : ""
+}
+
+output "alb_zone_id" {
+  description = "Route53 hosted zone ID of the ALB, for alias records. Empty when the ALB is disabled."
+  value       = length(data.aws_lb.alb) > 0 ? data.aws_lb.alb[0].zone_id : ""
+}
+


### PR DESCRIPTION
Closes the gap that let v4.0.0's release build fail after a green PR.

### The web app was compiled nowhere until a tag

`ci.yml` covered the two Go modules and Terraform; `release.yml` ran `pnpm build`. So the first signal that the frontend no longer compiled was a **failed release** — which is exactly what happened to v4.0.0.

The new job runs `pnpm build`, the same script `release.yml` runs, rather than a hand-rolled equivalent. That distinction is the point: `pnpm build` is `tsc -b && vite build`, and `tsc -b` is stricter than the `tsc --noEmit -p tsconfig.json` you would reach for by hand — the error that broke v4.0.0 **passes the latter and fails the former**. Anything less than the real command reproduces the same gap in a smaller form.

pnpm's version is read from `web/package.json`'s `packageManager` rather than pinned in the workflow, so this does not become a third place it must be kept in sync (CLAUDE.md documents the existing two).

### Linting is deliberately not gated yet

`biome ci src` reports **40 errors** on the tree as it stands — 21 `useButtonType`, 12 `noLabelWithoutControl`, the rest a11y and unused imports. None are from this change, and the obvious sweep is not safe: a `<button>` inside a form defaults to `type="submit"`, so adding `type="button"` to all 21 changes behaviour in whichever ones were submitting.

That is its own change with its own review. The step becomes a lint step when it lands, and the workflow says so.

### A latent bug found on the way

`env/main.hbs` has always emitted `domain_name = module.workloads.alb_dns_name` for a CloudFront origin of type `"alb"`, and `modules/workloads` has never had that output. Any config combining CloudFront with an ALB origin failed to plan on "Unsupported attribute" — invisible until someone wrote that exact combination.

`alb_dns_name` and `alb_zone_id` are now exported, empty when the ALB is off since the data source they read is not created then.

### Checks

`go test ./...`, `terraform fmt -check -recursive modules/workloads` and `terraform validate` pass. The new job is self-verifying — if it is wrong, this PR goes red.

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)