### PR TITLE
fix(modules): pin every module to the AWS provider major that actually deploys

### DIFF
--- a/modules/alb/versions.tf
+++ b/modules/alb/versions.tf
@@ -1,0 +1,29 @@
+# Pin the AWS provider to the major every generated environment actually runs.
+#
+# Without this, `terraform init -backend=false` — in CI
+# (.github/workflows/ci.yml) and in any standalone validation of this module —
+# resolves the newest hashicorp/aws, currently 6.x, while every generated
+# environment pins `~> 5.0` (env/main.hbs). CI then validates a provider no
+# environment runs.
+#
+# That is not cosmetic. It is how `data.aws_region.current.name` came to look
+# deprecated across this repository: `.name` is deprecated in 6.x and correct
+# in 5.x, and 5.x has no `.region` to move to — `try()` cannot bridge the two,
+# because an attribute the provider schema does not define fails at validate
+# time rather than at evaluation. Pinning the major is what makes the warning
+# go away honestly, instead of rewriting working 5.x code to match a provider
+# nothing here uses.
+#
+# modules/workloads carries a narrower floor (>= 5.34.0) for a reason specific
+# to EC2 capacity providers; this is the plain repository-wide constraint, and
+# `~> 5.0` matches env/main.hbs exactly.
+terraform {
+  required_version = ">= 1.2.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/amplify/versions.tf
+++ b/modules/amplify/versions.tf
@@ -1,0 +1,29 @@
+# Pin the AWS provider to the major every generated environment actually runs.
+#
+# Without this, `terraform init -backend=false` — in CI
+# (.github/workflows/ci.yml) and in any standalone validation of this module —
+# resolves the newest hashicorp/aws, currently 6.x, while every generated
+# environment pins `~> 5.0` (env/main.hbs). CI then validates a provider no
+# environment runs.
+#
+# That is not cosmetic. It is how `data.aws_region.current.name` came to look
+# deprecated across this repository: `.name` is deprecated in 6.x and correct
+# in 5.x, and 5.x has no `.region` to move to — `try()` cannot bridge the two,
+# because an attribute the provider schema does not define fails at validate
+# time rather than at evaluation. Pinning the major is what makes the warning
+# go away honestly, instead of rewriting working 5.x code to match a provider
+# nothing here uses.
+#
+# modules/workloads carries a narrower floor (>= 5.34.0) for a reason specific
+# to EC2 capacity providers; this is the plain repository-wide constraint, and
+# `~> 5.0` matches env/main.hbs exactly.
+terraform {
+  required_version = ">= 1.2.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/apprunner/versions.tf
+++ b/modules/apprunner/versions.tf
@@ -1,0 +1,29 @@
+# Pin the AWS provider to the major every generated environment actually runs.
+#
+# Without this, `terraform init -backend=false` — in CI
+# (.github/workflows/ci.yml) and in any standalone validation of this module —
+# resolves the newest hashicorp/aws, currently 6.x, while every generated
+# environment pins `~> 5.0` (env/main.hbs). CI then validates a provider no
+# environment runs.
+#
+# That is not cosmetic. It is how `data.aws_region.current.name` came to look
+# deprecated across this repository: `.name` is deprecated in 6.x and correct
+# in 5.x, and 5.x has no `.region` to move to — `try()` cannot bridge the two,
+# because an attribute the provider schema does not define fails at validate
+# time rather than at evaluation. Pinning the major is what makes the warning
+# go away honestly, instead of rewriting working 5.x code to match a provider
+# nothing here uses.
+#
+# modules/workloads carries a narrower floor (>= 5.34.0) for a reason specific
+# to EC2 capacity providers; this is the plain repository-wide constraint, and
+# `~> 5.0` matches env/main.hbs exactly.
+terraform {
+  required_version = ">= 1.2.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/appsync/versions.tf
+++ b/modules/appsync/versions.tf
@@ -1,0 +1,29 @@
+# Pin the AWS provider to the major every generated environment actually runs.
+#
+# Without this, `terraform init -backend=false` — in CI
+# (.github/workflows/ci.yml) and in any standalone validation of this module —
+# resolves the newest hashicorp/aws, currently 6.x, while every generated
+# environment pins `~> 5.0` (env/main.hbs). CI then validates a provider no
+# environment runs.
+#
+# That is not cosmetic. It is how `data.aws_region.current.name` came to look
+# deprecated across this repository: `.name` is deprecated in 6.x and correct
+# in 5.x, and 5.x has no `.region` to move to — `try()` cannot bridge the two,
+# because an attribute the provider schema does not define fails at validate
+# time rather than at evaluation. Pinning the major is what makes the warning
+# go away honestly, instead of rewriting working 5.x code to match a provider
+# nothing here uses.
+#
+# modules/workloads carries a narrower floor (>= 5.34.0) for a reason specific
+# to EC2 capacity providers; this is the plain repository-wide constraint, and
+# `~> 5.0` matches env/main.hbs exactly.
+terraform {
+  required_version = ">= 1.2.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/cloudfront/versions.tf
+++ b/modules/cloudfront/versions.tf
@@ -1,0 +1,29 @@
+# Pin the AWS provider to the major every generated environment actually runs.
+#
+# Without this, `terraform init -backend=false` — in CI
+# (.github/workflows/ci.yml) and in any standalone validation of this module —
+# resolves the newest hashicorp/aws, currently 6.x, while every generated
+# environment pins `~> 5.0` (env/main.hbs). CI then validates a provider no
+# environment runs.
+#
+# That is not cosmetic. It is how `data.aws_region.current.name` came to look
+# deprecated across this repository: `.name` is deprecated in 6.x and correct
+# in 5.x, and 5.x has no `.region` to move to — `try()` cannot bridge the two,
+# because an attribute the provider schema does not define fails at validate
+# time rather than at evaluation. Pinning the major is what makes the warning
+# go away honestly, instead of rewriting working 5.x code to match a provider
+# nothing here uses.
+#
+# modules/workloads carries a narrower floor (>= 5.34.0) for a reason specific
+# to EC2 capacity providers; this is the plain repository-wide constraint, and
+# `~> 5.0` matches env/main.hbs exactly.
+terraform {
+  required_version = ">= 1.2.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/cognito/versions.tf
+++ b/modules/cognito/versions.tf
@@ -1,0 +1,29 @@
+# Pin the AWS provider to the major every generated environment actually runs.
+#
+# Without this, `terraform init -backend=false` — in CI
+# (.github/workflows/ci.yml) and in any standalone validation of this module —
+# resolves the newest hashicorp/aws, currently 6.x, while every generated
+# environment pins `~> 5.0` (env/main.hbs). CI then validates a provider no
+# environment runs.
+#
+# That is not cosmetic. It is how `data.aws_region.current.name` came to look
+# deprecated across this repository: `.name` is deprecated in 6.x and correct
+# in 5.x, and 5.x has no `.region` to move to — `try()` cannot bridge the two,
+# because an attribute the provider schema does not define fails at validate
+# time rather than at evaluation. Pinning the major is what makes the warning
+# go away honestly, instead of rewriting working 5.x code to match a provider
+# nothing here uses.
+#
+# modules/workloads carries a narrower floor (>= 5.34.0) for a reason specific
+# to EC2 capacity providers; this is the plain repository-wide constraint, and
+# `~> 5.0` matches env/main.hbs exactly.
+terraform {
+  required_version = ">= 1.2.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/dns-root/versions.tf
+++ b/modules/dns-root/versions.tf
@@ -1,0 +1,29 @@
+# Pin the AWS provider to the major every generated environment actually runs.
+#
+# Without this, `terraform init -backend=false` — in CI
+# (.github/workflows/ci.yml) and in any standalone validation of this module —
+# resolves the newest hashicorp/aws, currently 6.x, while every generated
+# environment pins `~> 5.0` (env/main.hbs). CI then validates a provider no
+# environment runs.
+#
+# That is not cosmetic. It is how `data.aws_region.current.name` came to look
+# deprecated across this repository: `.name` is deprecated in 6.x and correct
+# in 5.x, and 5.x has no `.region` to move to — `try()` cannot bridge the two,
+# because an attribute the provider schema does not define fails at validate
+# time rather than at evaluation. Pinning the major is what makes the warning
+# go away honestly, instead of rewriting working 5.x code to match a provider
+# nothing here uses.
+#
+# modules/workloads carries a narrower floor (>= 5.34.0) for a reason specific
+# to EC2 capacity providers; this is the plain repository-wide constraint, and
+# `~> 5.0` matches env/main.hbs exactly.
+terraform {
+  required_version = ">= 1.2.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/domain/versions.tf
+++ b/modules/domain/versions.tf
@@ -1,0 +1,29 @@
+# Pin the AWS provider to the major every generated environment actually runs.
+#
+# Without this, `terraform init -backend=false` — in CI
+# (.github/workflows/ci.yml) and in any standalone validation of this module —
+# resolves the newest hashicorp/aws, currently 6.x, while every generated
+# environment pins `~> 5.0` (env/main.hbs). CI then validates a provider no
+# environment runs.
+#
+# That is not cosmetic. It is how `data.aws_region.current.name` came to look
+# deprecated across this repository: `.name` is deprecated in 6.x and correct
+# in 5.x, and 5.x has no `.region` to move to — `try()` cannot bridge the two,
+# because an attribute the provider schema does not define fails at validate
+# time rather than at evaluation. Pinning the major is what makes the warning
+# go away honestly, instead of rewriting working 5.x code to match a provider
+# nothing here uses.
+#
+# modules/workloads carries a narrower floor (>= 5.34.0) for a reason specific
+# to EC2 capacity providers; this is the plain repository-wide constraint, and
+# `~> 5.0` matches env/main.hbs exactly.
+terraform {
+  required_version = ">= 1.2.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/ecs_task/versions.tf
+++ b/modules/ecs_task/versions.tf
@@ -1,0 +1,29 @@
+# Pin the AWS provider to the major every generated environment actually runs.
+#
+# Without this, `terraform init -backend=false` — in CI
+# (.github/workflows/ci.yml) and in any standalone validation of this module —
+# resolves the newest hashicorp/aws, currently 6.x, while every generated
+# environment pins `~> 5.0` (env/main.hbs). CI then validates a provider no
+# environment runs.
+#
+# That is not cosmetic. It is how `data.aws_region.current.name` came to look
+# deprecated across this repository: `.name` is deprecated in 6.x and correct
+# in 5.x, and 5.x has no `.region` to move to — `try()` cannot bridge the two,
+# because an attribute the provider schema does not define fails at validate
+# time rather than at evaluation. Pinning the major is what makes the warning
+# go away honestly, instead of rewriting working 5.x code to match a provider
+# nothing here uses.
+#
+# modules/workloads carries a narrower floor (>= 5.34.0) for a reason specific
+# to EC2 capacity providers; this is the plain repository-wide constraint, and
+# `~> 5.0` matches env/main.hbs exactly.
+terraform {
+  required_version = ">= 1.2.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/efs/versions.tf
+++ b/modules/efs/versions.tf
@@ -1,0 +1,29 @@
+# Pin the AWS provider to the major every generated environment actually runs.
+#
+# Without this, `terraform init -backend=false` — in CI
+# (.github/workflows/ci.yml) and in any standalone validation of this module —
+# resolves the newest hashicorp/aws, currently 6.x, while every generated
+# environment pins `~> 5.0` (env/main.hbs). CI then validates a provider no
+# environment runs.
+#
+# That is not cosmetic. It is how `data.aws_region.current.name` came to look
+# deprecated across this repository: `.name` is deprecated in 6.x and correct
+# in 5.x, and 5.x has no `.region` to move to — `try()` cannot bridge the two,
+# because an attribute the provider schema does not define fails at validate
+# time rather than at evaluation. Pinning the major is what makes the warning
+# go away honestly, instead of rewriting working 5.x code to match a provider
+# nothing here uses.
+#
+# modules/workloads carries a narrower floor (>= 5.34.0) for a reason specific
+# to EC2 capacity providers; this is the plain repository-wide constraint, and
+# `~> 5.0` matches env/main.hbs exactly.
+terraform {
+  required_version = ">= 1.2.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/event_bridge_task/versions.tf
+++ b/modules/event_bridge_task/versions.tf
@@ -1,0 +1,29 @@
+# Pin the AWS provider to the major every generated environment actually runs.
+#
+# Without this, `terraform init -backend=false` — in CI
+# (.github/workflows/ci.yml) and in any standalone validation of this module —
+# resolves the newest hashicorp/aws, currently 6.x, while every generated
+# environment pins `~> 5.0` (env/main.hbs). CI then validates a provider no
+# environment runs.
+#
+# That is not cosmetic. It is how `data.aws_region.current.name` came to look
+# deprecated across this repository: `.name` is deprecated in 6.x and correct
+# in 5.x, and 5.x has no `.region` to move to — `try()` cannot bridge the two,
+# because an attribute the provider schema does not define fails at validate
+# time rather than at evaluation. Pinning the major is what makes the warning
+# go away honestly, instead of rewriting working 5.x code to match a provider
+# nothing here uses.
+#
+# modules/workloads carries a narrower floor (>= 5.34.0) for a reason specific
+# to EC2 capacity providers; this is the plain repository-wide constraint, and
+# `~> 5.0` matches env/main.hbs exactly.
+terraform {
+  required_version = ">= 1.2.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/postgres/versions.tf
+++ b/modules/postgres/versions.tf
@@ -1,0 +1,29 @@
+# Pin the AWS provider to the major every generated environment actually runs.
+#
+# Without this, `terraform init -backend=false` — in CI
+# (.github/workflows/ci.yml) and in any standalone validation of this module —
+# resolves the newest hashicorp/aws, currently 6.x, while every generated
+# environment pins `~> 5.0` (env/main.hbs). CI then validates a provider no
+# environment runs.
+#
+# That is not cosmetic. It is how `data.aws_region.current.name` came to look
+# deprecated across this repository: `.name` is deprecated in 6.x and correct
+# in 5.x, and 5.x has no `.region` to move to — `try()` cannot bridge the two,
+# because an attribute the provider schema does not define fails at validate
+# time rather than at evaluation. Pinning the major is what makes the warning
+# go away honestly, instead of rewriting working 5.x code to match a provider
+# nothing here uses.
+#
+# modules/workloads carries a narrower floor (>= 5.34.0) for a reason specific
+# to EC2 capacity providers; this is the plain repository-wide constraint, and
+# `~> 5.0` matches env/main.hbs exactly.
+terraform {
+  required_version = ">= 1.2.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/s3/versions.tf
+++ b/modules/s3/versions.tf
@@ -1,0 +1,29 @@
+# Pin the AWS provider to the major every generated environment actually runs.
+#
+# Without this, `terraform init -backend=false` — in CI
+# (.github/workflows/ci.yml) and in any standalone validation of this module —
+# resolves the newest hashicorp/aws, currently 6.x, while every generated
+# environment pins `~> 5.0` (env/main.hbs). CI then validates a provider no
+# environment runs.
+#
+# That is not cosmetic. It is how `data.aws_region.current.name` came to look
+# deprecated across this repository: `.name` is deprecated in 6.x and correct
+# in 5.x, and 5.x has no `.region` to move to — `try()` cannot bridge the two,
+# because an attribute the provider schema does not define fails at validate
+# time rather than at evaluation. Pinning the major is what makes the warning
+# go away honestly, instead of rewriting working 5.x code to match a provider
+# nothing here uses.
+#
+# modules/workloads carries a narrower floor (>= 5.34.0) for a reason specific
+# to EC2 capacity providers; this is the plain repository-wide constraint, and
+# `~> 5.0` matches env/main.hbs exactly.
+terraform {
+  required_version = ">= 1.2.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/ses/versions.tf
+++ b/modules/ses/versions.tf
@@ -1,0 +1,29 @@
+# Pin the AWS provider to the major every generated environment actually runs.
+#
+# Without this, `terraform init -backend=false` — in CI
+# (.github/workflows/ci.yml) and in any standalone validation of this module —
+# resolves the newest hashicorp/aws, currently 6.x, while every generated
+# environment pins `~> 5.0` (env/main.hbs). CI then validates a provider no
+# environment runs.
+#
+# That is not cosmetic. It is how `data.aws_region.current.name` came to look
+# deprecated across this repository: `.name` is deprecated in 6.x and correct
+# in 5.x, and 5.x has no `.region` to move to — `try()` cannot bridge the two,
+# because an attribute the provider schema does not define fails at validate
+# time rather than at evaluation. Pinning the major is what makes the warning
+# go away honestly, instead of rewriting working 5.x code to match a provider
+# nothing here uses.
+#
+# modules/workloads carries a narrower floor (>= 5.34.0) for a reason specific
+# to EC2 capacity providers; this is the plain repository-wide constraint, and
+# `~> 5.0` matches env/main.hbs exactly.
+terraform {
+  required_version = ">= 1.2.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/sqs/versions.tf
+++ b/modules/sqs/versions.tf
@@ -1,0 +1,29 @@
+# Pin the AWS provider to the major every generated environment actually runs.
+#
+# Without this, `terraform init -backend=false` — in CI
+# (.github/workflows/ci.yml) and in any standalone validation of this module —
+# resolves the newest hashicorp/aws, currently 6.x, while every generated
+# environment pins `~> 5.0` (env/main.hbs). CI then validates a provider no
+# environment runs.
+#
+# That is not cosmetic. It is how `data.aws_region.current.name` came to look
+# deprecated across this repository: `.name` is deprecated in 6.x and correct
+# in 5.x, and 5.x has no `.region` to move to — `try()` cannot bridge the two,
+# because an attribute the provider schema does not define fails at validate
+# time rather than at evaluation. Pinning the major is what makes the warning
+# go away honestly, instead of rewriting working 5.x code to match a provider
+# nothing here uses.
+#
+# modules/workloads carries a narrower floor (>= 5.34.0) for a reason specific
+# to EC2 capacity providers; this is the plain repository-wide constraint, and
+# `~> 5.0` matches env/main.hbs exactly.
+terraform {
+  required_version = ">= 1.2.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/vpc/versions.tf
+++ b/modules/vpc/versions.tf
@@ -1,0 +1,29 @@
+# Pin the AWS provider to the major every generated environment actually runs.
+#
+# Without this, `terraform init -backend=false` — in CI
+# (.github/workflows/ci.yml) and in any standalone validation of this module —
+# resolves the newest hashicorp/aws, currently 6.x, while every generated
+# environment pins `~> 5.0` (env/main.hbs). CI then validates a provider no
+# environment runs.
+#
+# That is not cosmetic. It is how `data.aws_region.current.name` came to look
+# deprecated across this repository: `.name` is deprecated in 6.x and correct
+# in 5.x, and 5.x has no `.region` to move to — `try()` cannot bridge the two,
+# because an attribute the provider schema does not define fails at validate
+# time rather than at evaluation. Pinning the major is what makes the warning
+# go away honestly, instead of rewriting working 5.x code to match a provider
+# nothing here uses.
+#
+# modules/workloads carries a narrower floor (>= 5.34.0) for a reason specific
+# to EC2 capacity providers; this is the plain repository-wide constraint, and
+# `~> 5.0` matches env/main.hbs exactly.
+terraform {
+  required_version = ">= 1.2.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## The 36 "deprecated" usages were not deprecated

`data.aws_region.current.name` is **correct** in AWS provider 5.x, which is what every generated environment runs (`~> 5.0` → 5.100.0). It is deprecated only in 6.x — and 5.x has no `.region` to move to.

The warnings appeared because **17 of 18 modules declared no provider constraint**, so `terraform init -backend=false` resolved the newest provider (6.60.0) and validated a version nothing deploys.

`modules/workloads/versions.tf` already named this exact problem when EC2 compute pools landed:

> *"CI was validating a provider no environment actually runs."*

This applies the same fix to the other modules. **Zero code changes to the `aws_region` usages** — they were right all along.

## Verified, not assumed

`try()` cannot bridge the two provider majors. An attribute the provider schema does not define fails at **validate** time, not evaluation, so the fallback never runs:

```
Error: Unsupported attribute
  value = try(data.aws_region.current.region, data.aws_region.current.name)
This object has no argument, nested block, or exported attribute named "region".
```

Tested against 5.100.0 before concluding it was impossible.

## Result

Every module re-initialised from scratch:

| | Before | After |
|---|---|---|
| Provider resolved | 6.60.0 | **5.100.0** |
| Deprecation warnings | 36 usages flagged | **0 warnings, all modules** |

The generated environment still inits and validates clean at 5.100.0 end to end.

## Two modules deliberately untouched

- **`modules/workloads`** keeps its narrower floor (`>= 5.34.0, < 6.0.0`), which exists for `aws_ecs_capacity_provider`'s `managed_draining`.
- **`modules/dns-delegation`** already pins `~> 5.0` inside `main.tf`, next to the `configuration_aliases` its cross-account provider needs. A second `required_providers` block is a hard error. That module also cannot be standalone-validated at all, because the `aws.root` alias has no caller — both pre-existing and unrelated to this change.

## About the other reported bug

The `generateEnvironmentFiles` path bug I flagged earlier **was already fixed on main** in `5df9320`, via `resolveEnvFilePath`. My report came from a stale base before the rebase. Verified against a current binary: `meroku generate dev` now finds `project/dev.yaml` with no root-level copy. No change needed, and none is in this PR.

## Provider 6.x is still open

Every module validates cleanly under 6.60.0 today, so the upgrade looks more tractable than the pin implies. It is deliberately **not** in this PR: `validate` passing says nothing about whether an existing stack *plans* clean across a provider major, and that is the risk worth testing on a real deployed stack before committing to it.

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)
